### PR TITLE
팔로우 리포지토리 구현 및 유저 프로필 조회 성공 케이스 구현

### DIFF
--- a/src/main/java/sssdev/tcc/domain/user/domain/User.java
+++ b/src/main/java/sssdev/tcc/domain/user/domain/User.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sssdev.tcc.domain.model.BaseEntity;
+import sssdev.tcc.domain.user.repository.FollowRepository;
 
 @Getter
 @Entity
@@ -32,12 +33,24 @@ public class User extends BaseEntity {
 
     @Column(nullable = false)
     private String description;
+    @Column(nullable = false)
+    private String profileUrl;
 
     @Builder
-    private User(String username, String password, String nickname, String description) {
+    private User(String username, String password, String nickname, String description,
+        String profileUrl) {
         this.username = username;
         this.password = password;
         this.nickname = nickname;
         this.description = description;
+        this.profileUrl = profileUrl;
+    }
+
+    public long getFollowingCount(FollowRepository repository) {
+        return repository.countFollowingByFromId(getId());
+    }
+
+    public long getFollowerCount(FollowRepository repository) {
+        return repository.countFollowerByToId(getId());
     }
 }

--- a/src/main/java/sssdev/tcc/domain/user/dto/response/ProfileResponse.java
+++ b/src/main/java/sssdev/tcc/domain/user/dto/response/ProfileResponse.java
@@ -1,10 +1,23 @@
 package sssdev.tcc.domain.user.dto.response;
 
+import sssdev.tcc.domain.user.domain.User;
+import sssdev.tcc.domain.user.repository.FollowRepository;
+
 public record ProfileResponse(
     String nickname,
-    Integer followerCount,
-    Integer followingCount,
+    long followerCount,
+    long followingCount,
     String profileImageUrl,
     String description
 ) {
+
+    public static ProfileResponse of(User user, FollowRepository followRepository) {
+        return new ProfileResponse(
+            user.getNickname(),
+            user.getFollowerCount(followRepository),
+            user.getFollowingCount(followRepository),
+            user.getProfileUrl(),
+            user.getDescription()
+        );
+    }
 }

--- a/src/main/java/sssdev/tcc/domain/user/repository/FollowRepository.java
+++ b/src/main/java/sssdev/tcc/domain/user/repository/FollowRepository.java
@@ -1,0 +1,11 @@
+package sssdev.tcc.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sssdev.tcc.domain.user.domain.Follow;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    long countFollowerByToId(Long from_id);
+
+    long countFollowingByFromId(Long from_id);
+}

--- a/src/main/java/sssdev/tcc/domain/user/service/UserService.java
+++ b/src/main/java/sssdev/tcc/domain/user/service/UserService.java
@@ -1,12 +1,20 @@
 package sssdev.tcc.domain.user.service;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import sssdev.tcc.domain.user.dto.response.ProfileResponse;
+import sssdev.tcc.domain.user.repository.FollowRepository;
+import sssdev.tcc.domain.user.repository.UserRepository;
 
+@RequiredArgsConstructor
 @Service
 public class UserService {
 
+    private final UserRepository userRepository;
+    private final FollowRepository followRepository;
+
     public ProfileResponse getProfile(Long id) {
-        return null;
+        var user = userRepository.findById(id).orElseThrow();
+        return ProfileResponse.of(user, followRepository);
     }
 }

--- a/src/test/java/sssdev/tcc/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/sssdev/tcc/domain/user/controller/UserControllerTest.java
@@ -1,7 +1,6 @@
 package sssdev.tcc.domain.user.controller;
 
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;

--- a/src/test/java/sssdev/tcc/domain/user/domain/UserTest.java
+++ b/src/test/java/sssdev/tcc/domain/user/domain/UserTest.java
@@ -1,0 +1,62 @@
+package sssdev.tcc.domain.user.domain;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import sssdev.tcc.domain.user.repository.FollowRepository;
+
+@DisplayName("유저 도메인 테스트")
+class UserTest {
+
+    @DisplayName("유저 팔로워 수 조회")
+    @Test
+    void get_follower_count() {
+        // given
+        var followRepository = mock(FollowRepository.class);
+        var followerCount = 1L;
+
+        var userId = 1L;
+        var user = User.builder()
+            .password("test")
+            .username("username")
+            .profileUrl("/api/test.png")
+            .description("description")
+            .nickname("핑크 공주")
+            .build();
+        setField(user, "id", userId);
+
+        given(followRepository.countFollowerByToId(userId)).willReturn(followerCount);
+        // when
+        long result = user.getFollowerCount(followRepository);
+        // then
+        then(result).isEqualTo(followerCount);
+    }
+
+    @DisplayName("유저 팔로잉 수 조회")
+    @Test
+    void get_following_count() {
+        // given
+        var followRepository = mock(FollowRepository.class);
+        var followingCount = 10L;
+
+        var userId = 1L;
+        var user = User.builder()
+            .password("test")
+            .username("username")
+            .profileUrl("/api/test.png")
+            .description("description")
+            .nickname("핑크 공주")
+            .build();
+        setField(user, "id", userId);
+
+        given(followRepository.countFollowingByFromId(userId)).willReturn(followingCount);
+        // when
+        long result = user.getFollowingCount(followRepository);
+        // then
+        then(result).isEqualTo(followingCount);
+    }
+}

--- a/src/test/java/sssdev/tcc/domain/user/service/UserServiceTest.java
+++ b/src/test/java/sssdev/tcc/domain/user/service/UserServiceTest.java
@@ -1,0 +1,68 @@
+package sssdev.tcc.domain.user.service;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sssdev.tcc.domain.user.domain.User;
+import sssdev.tcc.domain.user.dto.response.ProfileResponse;
+import sssdev.tcc.domain.user.repository.FollowRepository;
+import sssdev.tcc.domain.user.repository.UserRepository;
+
+@DisplayName("유저 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    FollowRepository followRepository;
+    UserService userService;
+
+    @BeforeEach
+    void init() {
+        this.userService = new UserService(userRepository, followRepository);
+    }
+
+    @DisplayName("프로필 조회")
+    @Nested
+    class GetProfile {
+
+        @DisplayName("유저의 프로필 조회 성공")
+        @Test
+        void success() {
+            // given
+            var userId = 1L;
+            var followerCount = 1L;
+            var followingCount = 10L;
+            var user = User.builder()
+                .password("test")
+                .username("username")
+                .profileUrl("/api/test.png")
+                .description("description")
+                .nickname("핑크 공주")
+                .build();
+            setField(user, "id", userId);
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(followRepository.countFollowerByToId(userId)).willReturn(followerCount);
+            given(followRepository.countFollowingByFromId(userId)).willReturn(followingCount);
+            // when
+            ProfileResponse profile = userService.getProfile(userId);
+            // then
+            then(profile.nickname()).isEqualTo(user.getNickname());
+            then(profile.followerCount()).isEqualTo(followerCount);
+            then(profile.followingCount()).isEqualTo(followingCount);
+            then(profile.profileImageUrl()).isEqualTo(user.getProfileUrl());
+            then(profile.description()).isEqualTo(user.getDescription());
+        }
+    }
+}


### PR DESCRIPTION
## 개요
팔로우 리포지토리 구현 및 유저 프로필 조회 성공 케이스 구현

## 작업사항
- 유저 서비스 프로필 조회 성공 케이스 구현
- FollowRepository 생성

## 변경로직
- 

## 관련 이슈
- #8
